### PR TITLE
Fix efiles missing requires.

### DIFF
--- a/lib/salt_hiera/plugins/efiles.rb
+++ b/lib/salt_hiera/plugins/efiles.rb
@@ -1,3 +1,7 @@
+require 'openssl'
+require 'base64'
+require 'salt_hiera/configuration'
+
 module SaltHiera
   module Plugins
     class Efiles
@@ -44,7 +48,7 @@ module SaltHiera
 
         public_key_x509 = OpenSSL::X509::Certificate.new( public_key_pem )
 
-        ciphertext = Base64.decode64(cipherbinary) 
+        ciphertext = Base64.decode64(cipherbinary)
         pkcs7 = OpenSSL::PKCS7.new( ciphertext )
 
         pkcs7.decrypt(private_key_rsa, public_key_x509)

--- a/lib/salt_hiera/plugins/eyaml.rb
+++ b/lib/salt_hiera/plugins/eyaml.rb
@@ -48,11 +48,8 @@ module SaltHiera
 
         public_key_x509 = OpenSSL::X509::Certificate.new( public_key_pem )
 
-        ciphertext = Base64.decode64(cipherbinary) 
+        ciphertext = Base64.decode64(cipherbinary)
         pkcs7 = OpenSSL::PKCS7.new( ciphertext )
-
-
-
 
         pkcs7.decrypt(private_key_rsa, public_key_x509)
 


### PR DESCRIPTION
When using encrypted files I got the following error:

```
2015-05-01 11:10:06,286 [salt.loaded.int.module.cmdmod][DEBUG   ] output: /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/plugins/
efiles.rb:41:in `decrypt': uninitialized constant SaltHiera::Plugins::Efiles::OpenSSL (NameError)
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/plugins/efiles.rb:25:in `recurse'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/plugins/efiles.rb:25:in `gsub'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/plugins/efiles.rb:25:in `recurse'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/plugins/efiles.rb:22:in `recurse'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/plugins/efiles.rb:21:in `each'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/plugins/efiles.rb:21:in `recurse'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/plugins/efiles.rb:10:in `process_file'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/salt_hiera.rb:74:in `to_yaml'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/salt_hiera.rb:71:in `each'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/salt_hiera.rb:71:in `to_yaml'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/salt_hiera.rb:62:in `each'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/salt_hiera.rb:62:in `to_yaml'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/lib/salt_hiera/CLI.rb:40:in `execute'
        from /var/lib/gems/1.8/gems/salthiera-0.3.2/bin/salthiera:7
        from /usr/local/bin/salthiera:19:in `load'
        from /usr/local/bin/salthiera:19
2015-05-01 11:10:06,287 [salt.loaded.int.pillar.salthiera][CRITICAL] SaltHiera YAML data failed to parse from conf /srv/salt/salthiera.yaml
```

Adding in the same requires used for eyaml fixes this issue.
